### PR TITLE
Adding handshakeTimeout support for Socket connect

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -22,6 +22,11 @@ class Socket extends EventEmitter {
   async connect(args = {}) {
     args = args || {};
     const address = args.address || 'localhost:4444';
+    
+    let clientOptions = {};
+    if (args.timeout) {
+        clientOptions.handshakeTimeout = args.timeout;
+    }
 
     if (this._connected) {
       this._socket.close();
@@ -30,7 +35,7 @@ class Socket extends EventEmitter {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       try {
-        await this._connect(address);
+        await this._connect(address, clientOptions);
         await this._authenticate(args.password);
         resolve();
       } catch (err) {
@@ -46,16 +51,17 @@ class Socket extends EventEmitter {
    * Opens a WebSocket connection to an obs-websocket server, but does not attempt any authentication.
    *
    * @param {String} address url without ws:// prefix.
+   * @param {WebSocket.ClientOptions} clientOptions ClientOptions to send into WebSocket.
    * @returns {Promise}
    * @private
    * @return {Promise} on attempted creation of WebSocket connection.
    */
-  async _connect(address) {
+  async _connect(address, clientOptions) {
     return new Promise((resolve, reject) => {
       let settled = false;
 
       debug('Attempting to connect to: %s', address);
-      this._socket = new WebSocket('ws://' + address);
+      this._socket = new WebSocket('ws://' + address, clientOptions);
 
       // We only handle the initial connection error.
       // Beyond that, the consumer is responsible for adding their own generic `error` event listener.

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -22,10 +22,10 @@ class Socket extends EventEmitter {
   async connect(args = {}) {
     args = args || {};
     const address = args.address || 'localhost:4444';
-    
-    let clientOptions = {};
+
+    const clientOptions = {};
     if (args.timeout) {
-        clientOptions.handshakeTimeout = args.timeout;
+      clientOptions.handshakeTimeout = args.timeout;
     }
 
     if (this._connected) {


### PR DESCRIPTION
### Description:
User can now provide timeout: [somenumber] as a connection attribute alongside address and password. This was needed because of intermittent connection problems and reconnection and the default timeout timer was too long.
