### PR TITLE
add error event to types

### DIFF
--- a/.travis/build-types.ts
+++ b/.travis/build-types.ts
@@ -196,6 +196,7 @@ declare module 'obs-websocket-js' {
   }
 
   interface EventHandlersDataMap {
+    "error": string;
     "ConnectionOpened": void;
     "ConnectionClosed": void;
     "AuthenticationSuccess": void;


### PR DESCRIPTION
**Related Issue**: #203 

The "error" event is highly recommended in the readme to add. But the event is not referenced in the type definition leading to an error when using the library with Typescript.

This patch adds the error event to the types definition.
