### PR TITLE
Multiple type building improvements/fixes

### DIFF
--- a/.travis/build-types.ts
+++ b/.travis/build-types.ts
@@ -50,7 +50,7 @@ interface ObjectType {
 }
 
 interface OutputType {
-  type: 'object';
+  type: 'ObsWebSocket.Output';
   properties: Tree;
   optional: boolean;
 }
@@ -402,7 +402,7 @@ function resolveType(inType: string): AnyType {
       return {
         type: 'array',
         items: {
-          type: 'object',
+          type: 'ObsWebSocket.Output',
           properties: {},
           optional: true
         },
@@ -454,14 +454,14 @@ function resolveType(inType: string): AnyType {
         type: 'ObsWebSocket.OBSStats',
         optional: isOptional
       };
+      case 'output':
+        return {
+          type: 'ObsWebSocket.Output',
+          properties: {},
+          optional: isOptional
+        };
     case 'string | object':
     case 'object':
-      return {
-        type: 'object',
-        properties: {},
-        optional: isOptional
-      };
-    case 'output':
       return {
         type: 'object',
         properties: {},

--- a/.travis/build-types.ts
+++ b/.travis/build-types.ts
@@ -490,12 +490,12 @@ function stringifyTypes(inputTypes: Tree, {terminator = ';', finalTerminator = t
       if (typeDef.items) {
         if (typeDef.items.type === 'object') {
           if (Object.keys(typeDef.items.properties).length > 0) {
-            returnString += `{ ${stringifyTypes(typeDef.items.properties, {name})}`;
+            returnString += `{${stringifyTypes(typeDef.items.properties, {name})}`;
             // Allows other arbitrary properties inside of "ExecuteBatch".
             if (name === 'ExecuteBatch') {
-              returnString += ' [k: string]: any;';
+              returnString += '[k: string]: any;';
             }
-            returnString += ' }[]';
+            returnString += '}[]';
           } else {
             returnString += 'Array<{[k: string]: any}>';
           }

--- a/.travis/build-types.ts
+++ b/.travis/build-types.ts
@@ -321,11 +321,14 @@ function unflattenAndResolveTypes(inputItems: RawType[]): Tree {
 
         const firstIntermediate = (currentNode as any)[nodeName];
         if (firstIntermediate.type === 'array') {
-          firstIntermediate.items = {
-            type: 'object',
-            properties: {},
-            optional: false
-          };
+          // Not sure if needed at all, but was here before and causing issues, so added a check.
+          if (!firstIntermediate.items.properties) {
+            firstIntermediate.items = {
+              type: 'object',
+              properties: {},
+              optional: true // Matches the "array<object>" case in "resolveType".
+            };
+          }
           currentNode = firstIntermediate.items.properties;
         } else {
           currentNode = firstIntermediate.properties;
@@ -487,7 +490,7 @@ function stringifyTypes(inputTypes: Tree, {terminator = ';', finalTerminator = t
       if (typeDef.items) {
         if (typeDef.items.type === 'object') {
           if (Object.keys(typeDef.items.properties).length > 0) {
-            returnString += `${stringifyTypes(typeDef.items.properties, {includePrefix: false, terminator: ''})}[]`;
+            returnString += `{ ${stringifyTypes(typeDef.items.properties)} }[]`;
           } else {
             returnString += 'Array<{[k: string]: any}>';
           }

--- a/.travis/build-types.ts
+++ b/.travis/build-types.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
+import * as got from 'got';
 import * as path from 'path';
 import * as prettier from 'prettier';
-import * as got from 'got';
 import deburr = require('lodash.deburr');
 
 interface RawType {
@@ -55,9 +55,14 @@ interface OutputType {
   optional: boolean;
 }
 
+interface OBSStatsType {
+  type: 'ObsWebSocket.OBSStats';
+  optional: boolean;
+}
+
 interface ArrayType {
   type: 'array';
-  items: PrimitiveType | ObjectType | OutputType | SceneType | SceneItemType | SceneItemTransformType;
+  items: PrimitiveType | ObjectType | OutputType | SceneType | SceneItemType | SceneItemTransformType | ScenesCollectionType;
   optional: boolean;
 }
 
@@ -76,8 +81,8 @@ interface SceneItemTransformType {
   optional: boolean;
 }
 
-interface OBSStatsType {
-  type: 'ObsWebSocket.OBSStats';
+interface ScenesCollectionType {
+  type: 'ObsWebSocket.ScenesCollection';
   optional: boolean;
 }
 
@@ -200,6 +205,13 @@ declare module 'obs-websocket-js' {
     "ConnectionClosed": void;
     "AuthenticationSuccess": void;
     "AuthenticationFailure": void;
+    "error": {
+      error: any;
+      message: string;
+      type: string;
+      // This would require importing all of the WebSocket types so leaving out for now.
+      // target: WebSocket;
+    };
     ${eventOverloads.join('\n\n  ')}
   }
 
@@ -423,6 +435,15 @@ function resolveType(inType: string): AnyType {
         },
         optional: isOptional
       };
+      case 'array<scenescollection>':
+        return {
+          type: 'array',
+          items: {
+            type: 'ObsWebSocket.ScenesCollection',
+            optional: true
+          },
+          optional: isOptional
+        };
     case 'sceneitemtransform':
       return {
         type: 'ObsWebSocket.SceneItemTransform',


### PR DESCRIPTION
<!--
  Please fill out the following information when creating a new pull request
-->

### Related Issue (if applicable):
N/A

### Description:
This PR changes/fixes a few things in relation to the type build script:
- Fixes an issue where the build would fail because the `ScenesCollection` typedef wasn't defined yet.
- Adds an `error` event type with (mostly) correct types. This makes #217 redundant and is a little more specific as the type returned should be more than a string, as the underlying error is a normal WebSocket error.
- Fixes the `Output` typedef not being used correctly.
- Fixes all of the events/requests that use `Array<Object>` parameters to actually have correct types; before they seemed to only have the type of their last property as the array type (for example `string[]`).
- Adds a small "hack" to allow arbitrary properties for the new `ExecuteBatch` request; you could probably have really good types depending on what is supplied/received for the `request-type` but not sure of the best way to do that; presumably with the type mapping?

Before Lange/Alex Van Camp went MIA, he did mention to me that something would need to be "fixed" with the type building for this library, although that message was in a Discord server that was deleted/I no longer have access to, so I'm not sure if these were the fixes, or if something more needs to be done. It appears to build just fine now and don't think there were any changes in `obs-websocket` itself that should make a difference?