### PR TITLE
Check that the send function's "args" parameter is actually an object

### DIFF
--- a/lib/OBSWebSocket.js
+++ b/lib/OBSWebSocket.js
@@ -29,6 +29,10 @@ class OBSWebSocket extends Socket {
         rejectReason = Status.REQUEST_TYPE_NOT_SPECIFIED;
       }
 
+      if (args && (typeof args !== 'object' || args === null || Array.isArray(args))) {
+        rejectReason = Status.ARGS_NOT_OBJECT;
+      }
+
       if (!this._connected) {
         rejectReason = Status.NOT_CONNECTED;
       }

--- a/lib/Status.js
+++ b/lib/Status.js
@@ -19,6 +19,10 @@ module.exports = {
     status: 'error',
     description: 'A Request Type was not specified.'
   },
+  ARGS_NOT_OBJECT: {
+    status: 'error',
+    description: 'The supplied argments parameter is not an object.'
+  },
 
   init() {
     for (const key in this) {


### PR DESCRIPTION
<!--
  Please fill out the following information when creating a new pull request
-->

### Related Issue (if applicable):
#223 

### Description:
This adds a simple check to the `send` function to make sure the supplied arguments parameter is *actually* an object (excluding arrays) and throws an error if not.

Added because of the referenced issue above where the author was able to supply an array, which the JavaScript somehow attempts to convert into a (broken) object, which gets sent without a `message-id`, and then the plugin returns an error message but because there is no `message-id` the `send` function gets stuck/hangs.