### PR TITLE
Fix event importing

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -1,5 +1,5 @@
 const WebSocket = require('isomorphic-ws');
-const EventEmitter = require('events');
+const { EventEmitter } = require('events');
 const hash = require('./util/authenticationHashing');
 const Status = require('./Status');
 const debug = require('debug')('obs-websocket-js:Socket');


### PR DESCRIPTION
This import fix solves the issue when building (anything that depends on obs-websocket-js) with esbuild or rollup.

See also: https://github.com/remorses/esbuild-plugins/issues/3#issuecomment-809345343

@haganbmj please let me know if you need more info.