### PR TITLE
Renaming GetGroupItemList to GetGroupSceneItemList

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1435,7 +1435,7 @@ export interface OBSRequestTypes {
 		 */
 		sceneName: string;
 	};
-	GetGroupItemList: {
+	GetGroupSceneItemList: {
 		/**
 		 * Name of the group to get the items of
 		 */
@@ -2288,7 +2288,7 @@ export interface OBSResponseTypes {
 		 */
 		sceneItems: JsonObject[];
 	};
-	GetGroupItemList: {
+	GetGroupSceneItemList: {
 		/**
 		 * Array of scene items in the group
 		 */


### PR DESCRIPTION
### Description:

I had a type error with the "GetGroupItemList" request. After looking around, found out that it is  "GetGroupSceneItemList" for v5

reference: https://docs.google.com/spreadsheets/d/1LfCZrbT8e7cSaKo_TuPDd-CJiptL7RSuo8iE63vMmMs/edit#gid=1402923009


