### PR TITLE
fix(types): correct RecordStateChanged typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -590,7 +590,20 @@ export interface OBSEventTypes {
 		/**
 		 * The specific state of the output
 		 */
-		outputState: string;
+		outputState: 'OBS_WEBSOCKET_OUTPUT_STARTING' | 'OBS_WEBSOCKET_OUTPUT_STOPPING';
+	} | {
+		/**
+		 * Whether the output is active
+		 */
+		outputActive: boolean;
+		/**
+		 * The specific state of the output
+		 */
+		outputState: 'OBS_WEBSOCKET_OUTPUT_STARTED' | 'OBS_WEBSOCKET_OUTPUT_STOPPED';
+		/**
+		 * The filename of the output recording
+		 */
+		outputPath: string;
 	};
 	ReplayBufferStateChanged: {
 		/**


### PR DESCRIPTION
### Description:

Correct typings: adds missing `outputPath` property when `outputState` is either 'OBS_WEBSOCKET_OUTPUT_STARTED' or 'OBS_WEBSOCKET_OUTPUT_STOPPED'.