### PR TITLE
fix: fix type error with moduleResolution node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "build": "npm-run-all clean build:*",
     "build:bundle": "microbundle -f modern,esm,cjs --no-compress src/{json,msgpack}.ts --generateTypes false",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:types": "tsc --emitDeclarationOnly && tsc --noEmit --moduleResolution bundler",
     "build:unpkg": "node scripts/generate-unpkg.js",
     "clean": "rimraf dist",
     "dev": "npm run build:bundle --watch",

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,5 +1,5 @@
 import createDebug from 'debug';
-import EventEmitter from 'eventemitter3';
+import {EventEmitter} from 'eventemitter3';
 // Import under alias so DOM's WebSocket type can be used
 import WebSocketIpml from 'isomorphic-ws';
 import type {Except, Merge, SetOptional} from 'type-fest';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,


### PR DESCRIPTION
<!--
  Please fill out the following information when creating a new pull request
-->

### Related Issue (if applicable):


### Description:

With `"moduleResolution": "node16"` set, users of this library receives incorrect `OBSWebsocket` type because internally the `eventemitter3` import fails.
