### PR TITLE
fix: don't export debug

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -8,7 +8,7 @@ import {WebSocketOpCode} from './types.js';
 import type {OutgoingMessageTypes, OutgoingMessage, OBSEventTypes, IncomingMessage, IncomingMessageTypes, OBSRequestTypes, OBSResponseTypes, RequestMessage, RequestBatchExecutionType, RequestBatchRequest, RequestBatchMessage, ResponseMessage, ResponseBatchMessage, RequestBatchOptions} from './types.js';
 import authenticationHashing from './utils/authenticationHashing.js';
 
-export const debug = createDebug('obs-websocket-js');
+const debug = createDebug('obs-websocket-js');
 
 export class OBSWebSocketError extends Error {
 	constructor(public code: number, message: string) {


### PR DESCRIPTION
<!--
  Please fill out the following information when creating a new pull request
-->

### Related Issue (if applicable):
None that I'm aware of.

### Description:
The debug library uses a slightly particular way of exporting a namespace. This causes an issue when mixing this library in a typescript module that uses `esModuleInterop = false`.

Since the debug library is only used in 1 file and shouldn't be used by a library user anyway the easiest fix is to not export the debug lib.