### PR TITLE
chore: update types to obs-websocket 5.6.3, remove old temp fix

### DIFF
--- a/scripts/build-types.ts
+++ b/scripts/build-types.ts
@@ -94,13 +94,6 @@ const {body: protocol} = await got<GeneratedProtocol>(`https://raw.githubusercon
 	responseType: 'json',
 });
 
-// fix oopsie in protocol.json (5.0.1)
-protocol.requests.forEach(req => {
-	if (req.requestType === 'GetGroupItemList') {
-		req.requestType = 'GetGroupSceneItemList';
-	}
-});
-
 const ENUMS: Record<string, EnumIdentifier[]> = {};
 protocol.enums.forEach(({enumType, enumIdentifiers}) => {
 	ENUMS[enumType] = enumIdentifiers;

--- a/src/types.ts
+++ b/src/types.ts
@@ -492,6 +492,10 @@ export interface OBSEventTypes {
 		 */
 		unversionedInputKind: string;
 		/**
+		 * Bitflag value for the caps that an input supports. See obs_source_info.output_flags in the libobs docs
+		 */
+		inputKindCaps: number;
+		/**
 		 * The settings configured to the input when it was created
 		 */
 		inputSettings: JsonObject;
@@ -1713,6 +1717,62 @@ export interface OBSRequestTypes {
 		 */
 		inputAudioTracks: JsonObject;
 	};
+	GetInputDeinterlaceMode: {
+		/**
+		 * Name of the input
+		 * @defaultValue Unknown
+		 */
+		inputName?: string;
+		/**
+		 * UUID of the input
+		 * @defaultValue Unknown
+		 */
+		inputUuid?: string;
+	};
+	SetInputDeinterlaceMode: {
+		/**
+		 * Name of the input
+		 * @defaultValue Unknown
+		 */
+		inputName?: string;
+		/**
+		 * UUID of the input
+		 * @defaultValue Unknown
+		 */
+		inputUuid?: string;
+		/**
+		 * Deinterlace mode for the input
+		 */
+		inputDeinterlaceMode: string;
+	};
+	GetInputDeinterlaceFieldOrder: {
+		/**
+		 * Name of the input
+		 * @defaultValue Unknown
+		 */
+		inputName?: string;
+		/**
+		 * UUID of the input
+		 * @defaultValue Unknown
+		 */
+		inputUuid?: string;
+	};
+	SetInputDeinterlaceFieldOrder: {
+		/**
+		 * Name of the input
+		 * @defaultValue Unknown
+		 */
+		inputName?: string;
+		/**
+		 * UUID of the input
+		 * @defaultValue Unknown
+		 */
+		inputUuid?: string;
+		/**
+		 * Deinterlace field order for the input
+		 */
+		inputDeinterlaceFieldOrder: string;
+	};
 	GetInputPropertiesListPropertyItems: {
 		/**
 		 * Name of the input
@@ -2863,6 +2923,20 @@ export interface OBSResponseTypes {
 		inputAudioTracks: JsonObject;
 	};
 	SetInputAudioTracks: undefined;
+	GetInputDeinterlaceMode: {
+		/**
+		 * Deinterlace mode of the input
+		 */
+		inputDeinterlaceMode: string;
+	};
+	SetInputDeinterlaceMode: undefined;
+	GetInputDeinterlaceFieldOrder: {
+		/**
+		 * Deinterlace field order of the input
+		 */
+		inputDeinterlaceFieldOrder: string;
+	};
+	SetInputDeinterlaceFieldOrder: undefined;
 	GetInputPropertiesListPropertyItems: {
 		/**
 		 * Array of items in the list property


### PR DESCRIPTION
### Description:
- Updates types to the latest update types to obs-websocket 5.6.3
- Removes old fix in build script, that is now resolved upstream in obs-websocket